### PR TITLE
ci: add macOS uv Python 3.13 test job

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,8 +26,6 @@ jobs:
 
   tests-macos-uv-python313:
     runs-on: macos-latest
-    env:
-      UV_SYSTEM_PYTHON: "1"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -36,9 +34,12 @@ jobs:
         with:
           python-version: "3.13"
           enable-cache: true
+      - name: Create virtual environment
+        run: |
+          uv venv --python 3.13
       - name: Install dependencies
         run: |
-          uv pip install .[dev]
+          uv pip install --python .venv/bin/python .[dev]
       - name: Run tests
         run: |
-          task test
+          .venv/bin/python -m taskipy test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,3 +23,22 @@ jobs:
       - name: Run tests
         run: |
           task test
+
+  tests-macos-uv-python313:
+    runs-on: macos-latest
+    env:
+      UV_SYSTEM_PYTHON: "1"
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install uv and set up Python 3.13
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+          enable-cache: true
+      - name: Install dependencies
+        run: |
+          uv pip install .[dev]
+      - name: Run tests
+        run: |
+          task test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,4 +42,5 @@ jobs:
           uv pip install --python .venv/bin/python .[dev]
       - name: Run tests
         run: |
-          .venv/bin/task test
+          export PATH="$PWD/.venv/bin:$PATH"
+          task test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,4 +42,4 @@ jobs:
           uv pip install --python .venv/bin/python .[dev]
       - name: Run tests
         run: |
-          .venv/bin/python -m taskipy test
+          .venv/bin/task test


### PR DESCRIPTION
Added a dedicated macOS GitHub Actions job to verify tests with Python 3.13 installed via uv, matching the environment that exposed the local failure (fixed at d0c1ee8e474590358e6c7f950226cbfb7de9e39b).