### PR TITLE
ci: add Linux uv Python 3.13 test job

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,8 +24,12 @@ jobs:
         run: |
           task test
 
-  tests-macos-uv-python313:
-    runs-on: macos-latest
+  tests-uv-python313:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- run the uv-based Python 3.13 test job on Ubuntu as well as macOS
- keep the existing macOS verification path while adding Linux coverage

## Testing
- not run locally (pytest is not installed in this worktree environment)
