### PR TITLE
ci: add macOS setup-python 3.13 test job

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -44,3 +44,20 @@ jobs:
         run: |
           export PATH="$PWD/.venv/bin:$PATH"
           task test
+
+  tests-macos-setup-python313:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install .[dev]
+      - name: Run tests
+        run: |
+          task test


### PR DESCRIPTION
## Summary
- add a dedicated macOS GitHub Actions job using actions/setup-python
- run that job with Python 3.13 only
- keep the existing uv-based macOS coverage unchanged

## Testing
- not run locally (workflow change only)
