### PR TITLE
Use packaging to normalize and merge dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pep723"
 description = "Implementation of PEP 723 (inline script metadata)"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["tomlkit"]
+dependencies = ["packaging", "tomlkit"]
 license = { text = "Apache Software License" }
 authors = [{ name = "nikkie", email = "takuyafjp+develop@gmail.com" }]
 keywords = ["inline script metadata"]

--- a/src/pep723/writer.py
+++ b/src/pep723/writer.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from typing import Any, cast
 
 import tomlkit
+from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
@@ -25,8 +26,8 @@ def _merge_key(
 
 
 def _merge_requirement_strings(existing: str, incoming: str) -> str:
-    existing_req = Requirement(existing)
-    incoming_req = Requirement(incoming)
+    existing_req = _parse_requirement(existing, "existing dependency")
+    incoming_req = _parse_requirement(incoming, "new dependency")
 
     if _merge_key(existing_req) != _merge_key(incoming_req):
         return existing
@@ -46,6 +47,27 @@ def _merge_requirement_strings(existing: str, incoming: str) -> str:
     return requirement
 
 
+def _parse_requirement(dep: str, source: str) -> Requirement:
+    try:
+        return Requirement(dep)
+    except InvalidRequirement as exc:
+        raise ValueError(f"Invalid {source}: {dep!r}") from exc
+
+
+def _merge_into_requirements_list(
+    deps: list[str], dep: str, dep_source: str, existing_source: str
+) -> None:
+    req = _parse_requirement(dep, dep_source)
+    key = _merge_key(req)
+    for index, existing in enumerate(deps):
+        existing_req = _parse_requirement(existing, existing_source)
+        if _merge_key(existing_req) == key:
+            deps[index] = _merge_requirement_strings(existing, dep)
+            break
+    else:
+        deps.append(dep)
+
+
 def _strip_comment_prefix(content: str) -> str:
     return "".join(
         line[2:] if line.startswith("# ") else line[1:]
@@ -63,15 +85,12 @@ def _add_comment_prefix(toml_str: str) -> str:
 def _deduplicate(deps: Sequence[str]) -> list[str]:
     result: list[str] = []
     for dep in deps:
-        req = Requirement(dep)
-        key = _merge_key(req)
-        for index, existing in enumerate(result):
-            existing_req = Requirement(existing)
-            if _merge_key(existing_req) == key:
-                result[index] = _merge_requirement_strings(existing, dep)
-                break
-        else:
-            result.append(dep)
+        _merge_into_requirements_list(
+            result,
+            dep,
+            "new dependency",
+            "new dependency",
+        )
     return result
 
 
@@ -121,17 +140,12 @@ def add_dependencies(script: str, new_deps: Sequence[str]) -> str:
             config.add("dependencies", arr)
         existing_deps = cast(list[Any], config["dependencies"])
         for dep in new_deps:
-            req = Requirement(dep)
-            key = _merge_key(req)
-            for index, existing in enumerate(existing_deps):
-                existing_req = Requirement(existing)
-                if _merge_key(existing_req) == key:
-                    existing_deps[index] = _merge_requirement_strings(
-                        existing, dep
-                    )
-                    break
-            else:
-                existing_deps.append(dep)
+            _merge_into_requirements_list(
+                existing_deps,
+                dep,
+                "new dependency",
+                "dependency in script block",
+            )
         new_content = _add_comment_prefix(tomlkit.dumps(config))
         start, end = match.span("content")
         return script[:start] + new_content + script[end:]

--- a/src/pep723/writer.py
+++ b/src/pep723/writer.py
@@ -5,31 +5,45 @@ from collections.abc import Sequence
 from typing import Any, cast
 
 import tomlkit
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 from pep723.parser import REGEX
 
 _CODING_RE = re.compile(r"^[ \t\f]*#.*?coding[:=][ \t]*([-\w.]+)", re.ASCII)
 
 
-def _pkg_key(specifier: str) -> str:
-    """Build a canonical dedup key from a dependency specifier.
+def _merge_key(
+    requirement: Requirement,
+) -> tuple[str, str, str | None, str | None]:
+    return (
+        canonicalize_name(requirement.name),
+        str(requirement.specifier),
+        requirement.url,
+        None if requirement.marker is None else str(requirement.marker),
+    )
 
-    Extras (e.g. requests[socks]) and environment markers
-    (e.g. ; python_version < '3.10') are preserved so that distinct
-    conditional requirements are NOT collapsed into one entry.
-    """
-    semicolon = specifier.find(";")
-    if semicolon != -1:
-        requirement = specifier[:semicolon]
-        marker = specifier[semicolon:]
-    else:
-        requirement = specifier
-        marker = ""
-    raw_name = re.split(r"[<>=!~,@\s]", requirement, maxsplit=1)[0]
-    name = re.sub(r"[-_.]+", "_", raw_name).lower()
-    if marker:
-        return name + marker
-    return name
+
+def _merge_requirement_strings(existing: str, incoming: str) -> str:
+    existing_req = Requirement(existing)
+    incoming_req = Requirement(incoming)
+
+    if _merge_key(existing_req) != _merge_key(incoming_req):
+        return existing
+
+    merged_extras = sorted(existing_req.extras | incoming_req.extras)
+    if merged_extras == sorted(existing_req.extras):
+        return existing
+
+    requirement = existing_req.name
+    if merged_extras:
+        requirement += f"[{','.join(merged_extras)}]"
+    requirement += str(existing_req.specifier)
+    if existing_req.url is not None:
+        requirement += f" @ {existing_req.url}"
+    if existing_req.marker is not None:
+        requirement += f"; {existing_req.marker}"
+    return requirement
 
 
 def _strip_comment_prefix(content: str) -> str:
@@ -47,13 +61,17 @@ def _add_comment_prefix(toml_str: str) -> str:
 
 
 def _deduplicate(deps: Sequence[str]) -> list[str]:
-    seen: set[str] = set()
     result: list[str] = []
     for dep in deps:
-        key = _pkg_key(dep)
-        if key not in seen:
+        req = Requirement(dep)
+        key = _merge_key(req)
+        for index, existing in enumerate(result):
+            existing_req = Requirement(existing)
+            if _merge_key(existing_req) == key:
+                result[index] = _merge_requirement_strings(existing, dep)
+                break
+        else:
             result.append(dep)
-            seen.add(key)
     return result
 
 
@@ -102,12 +120,18 @@ def add_dependencies(script: str, new_deps: Sequence[str]) -> str:
             arr.multiline(True)
             config.add("dependencies", arr)
         existing_deps = cast(list[Any], config["dependencies"])
-        existing_names = {_pkg_key(d) for d in existing_deps}
         for dep in new_deps:
-            key = _pkg_key(dep)
-            if key not in existing_names:
+            req = Requirement(dep)
+            key = _merge_key(req)
+            for index, existing in enumerate(existing_deps):
+                existing_req = Requirement(existing)
+                if _merge_key(existing_req) == key:
+                    existing_deps[index] = _merge_requirement_strings(
+                        existing, dep
+                    )
+                    break
+            else:
                 existing_deps.append(dep)
-                existing_names.add(key)
         new_content = _add_comment_prefix(tomlkit.dumps(config))
         start, end = match.span("content")
         return script[:start] + new_content + script[end:]

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -199,9 +199,8 @@ import sys
             """\
 # /// script
 # dependencies = [
-#   "httpx",
-#   "rich",
 #   "httpx[http2]",
+#   "rich",
 # ]
 # ///
 
@@ -307,7 +306,7 @@ import sys
         "create block for empty script",
         "deduplicate in new_deps",
         "create dependencies key when block has none",
-        "extras variant is not a duplicate of bare package",
+        "extras variant replaces bare package",
         "preserve shebang when inserting new block",
         "preserve shebang-only file when inserting new block",
         "preserve shebang and encoding cookie",
@@ -342,6 +341,44 @@ def test_add_dependencies_new_block_no_crlf_injection() -> None:
     script = "import time\nimport sys\n"
     result = add_dependencies(script, ["requests"])
     assert "\r\n" not in result
+
+
+def test_add_dependencies_merges_multiple_extra_variants() -> None:
+    script = """\
+# /// script
+# dependencies = [
+#   "httpx[http2]",
+# ]
+# ///
+"""
+    expected = """\
+# /// script
+# dependencies = [
+#   "httpx[brotli,http2]",
+# ]
+# ///
+"""
+    assert add_dependencies(script, ["httpx[brotli]"]) == expected
+
+
+def test_add_dependencies_merges_duplicate_new_deps_with_distinct_extras() -> (
+    None
+):
+    script = """\
+import time
+"""
+    expected = """\
+# /// script
+# dependencies = [
+#   "httpx[brotli,http2]",
+# ]
+# ///
+
+import time
+"""
+    assert (
+        add_dependencies(script, ["httpx[http2]", "httpx[brotli]"]) == expected
+    )
 
 
 def test_raise_error_when_multiple_script_blocks_found() -> None:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -393,3 +393,25 @@ def test_raise_error_when_multiple_script_blocks_found() -> None:
 """
     with pytest.raises(ValueError):
         add_dependencies(script, ["requests"])
+
+
+def test_raise_error_for_invalid_new_dependency() -> None:
+    with pytest.raises(
+        ValueError, match=r"Invalid new dependency: 'not valid @ @'"
+    ):
+        add_dependencies("", ["not valid @ @"])
+
+
+def test_raise_error_for_invalid_existing_dependency() -> None:
+    script = """\
+# /// script
+# dependencies = [
+#   "not valid @ @",
+# ]
+# ///
+"""
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid dependency in script block: 'not valid @ @'",
+    ):
+        add_dependencies(script, ["requests"])

--- a/tests/tool/test_venv.py
+++ b/tests/tool/test_venv.py
@@ -18,6 +18,5 @@ def test_create_venv_with_dependencies(tmp_path):
     create_with_dependencies(tmp_path, dependencies)
 
     assert (
-        site_packages_dir(tmp_path)
-        / "the_solitary_castle_in_the_mirror"
+        site_packages_dir(tmp_path) / "the_solitary_castle_in_the_mirror"
     ).exists()


### PR DESCRIPTION
## Summary
- use packaging.Requirement to validate and normalize dependency handling for PEP 508-style requirements
- merge duplicate requirements by canonical name, specifier, url, and marker while combining extras into a single entry
- add coverage for extras merging and include packaging as a runtime dependency

## Testing
- uv run --extra dev task test
- result: 28 passed, 1 failed in tests/tool/test_venv.py::test_create_venv_with_dependencies because the expected installed package path was not created in this environment